### PR TITLE
chore: group related dependency updates in renovate/dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,33 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      hardhat:
+        patterns:
+          - "hardhat"
+          - "hardhat-*"
+          - "@nomicfoundation/*"
+          - "@nomiclabs/*"
+          - "@openzeppelin/hardhat-upgrades"
+          - "solidity-coverage"
+      typechain:
+        patterns:
+          - "typechain"
+          - "@typechain/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+          - "@types/eslint"
+          - "@types/eslint__js"
+      testing:
+        patterns:
+          - "mocha"
+          - "chai"
+          - "sinon"
+          - "sinon-chai"
+          - "@types/mocha"
+          - "@types/chai"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,44 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "autoApprove": true
+    },
+    {
+      "groupName": "hardhat",
+      "matchPackageNames": [
+        "hardhat",
+        "hardhat-**",
+        "@nomicfoundation/**",
+        "@nomiclabs/**",
+        "@openzeppelin/hardhat-upgrades",
+        "solidity-coverage"
+      ]
+    },
+    {
+      "groupName": "typechain",
+      "matchPackageNames": ["typechain", "@typechain/**"]
+    },
+    {
+      "groupName": "eslint",
+      "matchPackageNames": [
+        "eslint",
+        "eslint-**",
+        "@eslint/**",
+        "@typescript-eslint/**",
+        "typescript-eslint",
+        "@types/eslint",
+        "@types/eslint__js"
+      ]
+    },
+    {
+      "groupName": "testing",
+      "matchPackageNames": [
+        "mocha",
+        "chai",
+        "sinon",
+        "sinon-chai",
+        "@types/mocha",
+        "@types/chai"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Groups semantically related packages so they are upgraded together in a single update PR, e.g. all hardhat packages. Applied to both `.github/renovate.json` and `.github/dependabot.yml`.

| Group | Packages covered |
| --- | --- |
| hardhat | `hardhat`, `hardhat-gas-reporter`, `solidity-coverage`, `@nomicfoundation/hardhat-chai-matchers`, `@nomicfoundation/hardhat-ethers`, `@nomicfoundation/hardhat-ignition`, `@nomicfoundation/hardhat-ignition-ethers`, `@nomicfoundation/hardhat-network-helpers`, `@nomicfoundation/hardhat-toolbox`, `@nomicfoundation/hardhat-verify`, `@nomicfoundation/ignition-core` |
| typechain | `typechain`, `@typechain/ethers-v6`, `@typechain/hardhat` |
| eslint | `eslint`, `@eslint/js`, `typescript-eslint`, `@types/eslint`, `@types/eslint__js` |
| testing | `chai`, `@types/chai`, `@types/mocha` |